### PR TITLE
Added an option to set a custom source tarball name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-# git-rpm-tools v0.1 prealpha
+# git-rpm-tools v0.7
 
-An utility which aims to trivialize creating RPMs from an existing git repository. The workflow is as follows:
+An utility which aims to trivialize creating RPMs from an existing git repository.
+
+The tool handles creation and cleanup of the rpmbuild tree, archiving the source code,
+moving .spec, .tar.gz, and .rpm files around, and performs various checks.
+
+## Usage
+
+The default workflow is as follows:
 
 1. Create and drop a .spec file in `dist/` directory of an existing git repository
-2. Run git-rpm-tools in the repository root
-3. Get .rpm (or .src.rpm or both) in the repository root
+2. Run `git-rpm-tools` in the repository root
+3. The .rpm (or .src.rpm or both) will be generated in the repository root
 
-The tool handles creation and cleanup of the rpmbuild tree, archiving the source code, moving .spec, .tar.gz, and .rpm files around, and performs various checks.
+See `git-rpm-tools -h` for list of all available options and customizations.
+Custom branch, package, source tarball name, and .spec file to use can be defined.
+
+## Dependencies
+
+`rpmdevtools` package is reqiuired to run the tool.

--- a/dist/git-rpm-tools.spec
+++ b/dist/git-rpm-tools.spec
@@ -1,5 +1,5 @@
 Name:           git-rpm-tools
-Version:        0.6
+Version:        0.7
 Release:        1%{?dist}
 Summary:        RPM packaging helper for Git repos
 
@@ -38,6 +38,10 @@ cp ./scripts/git-rpm-tools %{buildroot}/usr/local/bin
 /usr/local/bin/*
 
 %changelog
+* Wed Aug 14 2024 Derbenev, Anton <aderbenev@bnl.gov> - 0.7-1
+- Added an option to specify a custom source tarball name
+- Minor touch-ups to help message and options order
+
 * Tue Oct 03 2023 Wlodek, Jakub <jwlodek@bnl.gov> - 0.6-1
 - Add option to set install location for artifacts via an environment variable.
 

--- a/scripts/git-rpm-tools
+++ b/scripts/git-rpm-tools
@@ -100,7 +100,7 @@ function build_prep() {
     # Archive selected repo branch, put in SOURCES
     echo "Archiving sources to: $BUILD_TREE/SOURCES"
     mkdir -p $BUILD_TREE/SOURCES
-    git archive --prefix=${TARBALL_NAME%.tar.gz} --format=tar.gz $GIT_BRANCH > $BUILD_TREE/SOURCES/$TARBALL_NAME
+    git archive --prefix="${TARBALL_NAME%.tar.gz}/" --format=tar.gz $GIT_BRANCH > $BUILD_TREE/SOURCES/$TARBALL_NAME
 
     # Figure out dist identifier, e.g. epochtime-[branchname-]osver
     # using release number from spec for now

--- a/scripts/git-rpm-tools
+++ b/scripts/git-rpm-tools
@@ -81,6 +81,10 @@ function build_prep() {
     # or rpmspec -q --queryformat='%{version}-%{release}' <>.spec
     PKG_VERSION=$(rpmspec -q --queryformat='%{version}' --define "debug_package %{nil}" $SPEC_FILE)
     echo "Selecting package version: $PKG_VERSION"
+
+    # Figure out source tarball name
+    TARBALL_NAME=${TARBALL_NAME:-"$PKG_NAME-$PKG_VERSION.tar.gz"}
+    echo "Selecting tarball name: $TARBALL_NAME"
     #
     #
     # End resolve vars
@@ -96,7 +100,7 @@ function build_prep() {
     # Archive selected repo branch, put in SOURCES
     echo "Archiving sources to: $BUILD_TREE/SOURCES"
     mkdir -p $BUILD_TREE/SOURCES
-    git archive --prefix="$PKG_NAME-$PKG_VERSION/" --format=tar.gz $GIT_BRANCH > $BUILD_TREE/SOURCES/$PKG_NAME-$PKG_VERSION.tar.gz
+    git archive --prefix=${TARBALL_NAME%.tar.gz} --format=tar.gz $GIT_BRANCH > $BUILD_TREE/SOURCES/$TARBALL_NAME
 
     # Figure out dist identifier, e.g. epochtime-[branchname-]osver
     # using release number from spec for now
@@ -168,7 +172,7 @@ function clean() {
 }
 
 function usage() {
-    printf "Usage: %s [-v] [-x] [-b branch] [-n pkgname] [-s specfile] [cmd]\n" `basename $0`
+    printf "Usage: %s [-v] [-x] [-d] [-a] [-b branch] [-t tarball] [-n pkgname] [-s specfile] [cmd]\n" `basename $0`
     echo "
 Available options:
   v                                          - be verbose
@@ -176,9 +180,11 @@ Available options:
   d                                          - be dirty, do not clean up build space
   a                                          - absorb uncommitted changes when packing source (overrides -b)
   b                                          - branch to select when packing source (current branch is default)
+  t                                          - tarball name to use when packing source
   n                                          - package name to use (defaults to dir name)
   s                                          - .spec file to use (defaults to package name)
   i                                          - print version info
+  h                                          - show this help
 Available commands:
   bb                                         - perform RPM build (binary)
   bs                                         - perform SRPM build (source)
@@ -187,18 +193,19 @@ Available commands:
   exit 2
 }
 
-while getopts 'vxdhiab:n:s:' arg
+while getopts 'vxdhiab:n:s:t:' arg
 do
     case $arg in
-    a)      ABSORB_LOCAL=1;;
-    b)      GIT_BRANCH=$OPTARG;;
-    n)      PKG_NAME=$OPTARG;;
-    s)      SPEC_FILE=$OPTARG;;
     v)      VERB=1;;
     x)      set -x;;
     d)      DIRTY=1;;
-    h)      usage;;
+    a)      ABSORB_LOCAL=1;;
+    b)      GIT_BRANCH=$OPTARG;;
+    t)      TARBALL_NAME=$OPTARG;;
+    n)      PKG_NAME=$OPTARG;;
+    s)      SPEC_FILE=$OPTARG;;
     i)      echo "git-rpm-tools version ${VERSION}" && exit 0;;
+    h)      usage;;
     ?)      usage;;
     esac
 done


### PR DESCRIPTION
Encountered a case when the specfile was defining `Source0` as `<name>-v<version>` instead of the default `<name>-<version>`. `rpmbuild` fails in this case as it cannot find a correspondingly named source tarball.

This adds an option to set up a custom tarball name as a work-around for such cases.