### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/self-build-rpm.yml
+++ b/.github/workflows/self-build-rpm.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - run: ./scripts/git-rpm-tools
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
